### PR TITLE
debug: task_fan 起動後5分間を旧test.pyのfanテストと同じ実装で動作

### DIFF
--- a/Code/api_expansion.py
+++ b/Code/api_expansion.py
@@ -78,10 +78,9 @@ class FNK0100:
     def set_power_on_check(self, state):
         self.i2c.write(self.REG_POWER_ON_CHECK, state)
 
-    # 获取温度方法 — 16-bit big-endian millidegrees → degrees Celsius
+    # 获取温度方法
     def get_temp(self):
-        raw = self.i2c.read(self.REG_TEMP_READ, 2)
-        return ((raw[0] << 8) | raw[1]) / 1000.0
+        return self.i2c.read(self.REG_TEMP_READ) / 10
 
     # 风扇控制方法
     def set_fan_mode(self, mode):
@@ -167,10 +166,9 @@ class FNK0107:
     def set_power_on_check(self, state):
         self.i2c.write(self.REG_POWER_ON_CHECK, state)
 
-    # 获取温度方法 — 16-bit little-endian millidegrees → degrees Celsius
+    # 获取温度方法
     def get_temp(self):
-        raw = self.i2c.read(self.REG_TEMP_READ, 2)
-        return (raw[0] | (raw[1] << 8)) / 1000.0
+        return self.i2c.read(self.REG_TEMP_READ) / 10
 
     # 风扇控制方法
     def set_fan_mode(self, mode):

--- a/Code/api_expansion.py
+++ b/Code/api_expansion.py
@@ -80,7 +80,8 @@ class FNK0100:
 
     # 获取温度方法
     def get_temp(self):
-        return self.i2c.read(self.REG_TEMP_READ) / 10
+        raw = self.i2c.read(self.REG_TEMP_READ, 2)
+        return ((raw[0] << 8) | raw[1]) / 1000.0
 
     # 风扇控制方法
     def set_fan_mode(self, mode):
@@ -168,7 +169,8 @@ class FNK0107:
 
     # 获取温度方法
     def get_temp(self):
-        return self.i2c.read(self.REG_TEMP_READ) / 10
+        raw = self.i2c.read(self.REG_TEMP_READ, 2)
+        return (raw[0] | (raw[1] << 8)) / 1000.0
 
     # 风扇控制方法
     def set_fan_mode(self, mode):

--- a/Code/api_expansion.py
+++ b/Code/api_expansion.py
@@ -60,7 +60,7 @@ class FNK0100:
     REG_FAN_DUTY          = 0x06
     REG_FAN_THRESHOLD     = 0x07
     REG_POWER_ON_CHECK    = 0x08
-    
+
     REG_LED_SPECIFIED_READ = 0xf4
     REG_LED_ALL_READ      = 0xf5
     REG_LED_MODE_READ     = 0xf6
@@ -70,17 +70,18 @@ class FNK0100:
     REG_FAN1_DUTY_READ    = 0xfa
     REG_FAN_THRESHOLD_READ = 0xfb
     REG_TEMP_READ         = 0xfc
-    
+
     def __init__(self, i2c_controller):
         self.i2c = i2c_controller
-    
+
     # 设置开机检查
     def set_power_on_check(self, state):
         self.i2c.write(self.REG_POWER_ON_CHECK, state)
 
-    # 获取温度方法
+    # 获取温度方法 — 16-bit big-endian millidegrees → degrees Celsius
     def get_temp(self):
-        return self.i2c.read(self.REG_TEMP_READ)
+        raw = self.i2c.read(self.REG_TEMP_READ, 2)
+        return ((raw[0] << 8) | raw[1]) / 1000.0
 
     # 风扇控制方法
     def set_fan_mode(self, mode):
@@ -166,9 +167,10 @@ class FNK0107:
     def set_power_on_check(self, state):
         self.i2c.write(self.REG_POWER_ON_CHECK, state)
 
-    # 获取温度方法
+    # 获取温度方法 — 16-bit little-endian millidegrees → degrees Celsius
     def get_temp(self):
-        return self.i2c.read(self.REG_TEMP_READ)
+        raw = self.i2c.read(self.REG_TEMP_READ, 2)
+        return (raw[0] | (raw[1] << 8)) / 1000.0
 
     # 风扇控制方法
     def set_fan_mode(self, mode):

--- a/Code/app_config.json
+++ b/Code/app_config.json
@@ -4,21 +4,28 @@
     "follow_led_color": 0
   },
   "LED": {
-    "mode": 3,
+    "mode": 0,
     "red_value": 0,
-    "green_value": 206,
-    "blue_value": 209,
+    "green_value": 0,
+    "blue_value": 255,
     "task_name": "task_led.py",
     "is_run_on_startup": true
   },
   "Fan": {
     "mode": 0,
     "task_name": "task_fan.py",
-    "is_run_on_startup": true,
+    "is_run_on_startup": false,
     "mode1_fan_group1": 75,
     "mode1_fan_group2": 75,
     "mode2_low_temp_threshold": 30,
-    "mode2_high_temp_threshold": 50
+    "mode2_high_temp_threshold": 50,
+    "mode1_fan_group3": 75,
+    "mode2_temp_schmitt": 3,
+    "mode2_low_speed": 75,
+    "mode2_middle_speed": 125,
+    "mode2_high_speed": 175,
+    "mode3_min_speed_mapping": 0,
+    "mode3_max_speed_mapping": 255
   },
   "OLED": {
     "task_name": "task_oled.py",
@@ -26,24 +33,24 @@
     "screen1": {
       "data_format": 0,
       "time_format": 0,
-      "display_time": 3.0,
+      "display_time": 2.0,
       "is_run_on_oled": true
     },
     "screen2": {
       "interchange": 0,
-      "display_time": 3.0,
+      "display_time": 2.0,
       "is_run_on_oled": true
     },
     "screen3": {
       "interchange": 0,
-      "display_time": 3.0,
+      "display_time": 2.0,
       "cpu_temp_celsius_or_fahrenheit": false,
       "case_temp_celsius_or_fahrenheit": false,
       "is_run_on_oled": true
     },
     "screen4": {
       "interchange": 0,
-      "display_time": 3.0,
+      "display_time": 2.0,
       "is_run_on_oled": true
     },
     "screen5": {
@@ -52,7 +59,7 @@
     }
   },
   "Service": {
-    "is_exist_on_rpi": false,
-    "is_run_on_startup": false
+    "is_exist_on_rpi": true,
+    "is_run_on_startup": true
   }
 }

--- a/Code/app_config.json
+++ b/Code/app_config.json
@@ -33,28 +33,28 @@
     "screen1": {
       "data_format": 0,
       "time_format": 0,
-      "display_time": 2.0,
+      "display_time": 6.0,
       "is_run_on_oled": true
     },
     "screen2": {
       "interchange": 0,
-      "display_time": 2.0,
+      "display_time": 6.0,
       "is_run_on_oled": true
     },
     "screen3": {
       "interchange": 0,
-      "display_time": 2.0,
+      "display_time": 6.0,
       "cpu_temp_celsius_or_fahrenheit": false,
       "case_temp_celsius_or_fahrenheit": false,
       "is_run_on_oled": true
     },
     "screen4": {
       "interchange": 0,
-      "display_time": 2.0,
+      "display_time": 6.0,
       "is_run_on_oled": true
     },
     "screen5": {
-      "display_time": 3.0,
+      "display_time": 6.0,
       "is_run_on_oled": true
     }
   },

--- a/Code/app_config.json
+++ b/Code/app_config.json
@@ -1,0 +1,58 @@
+{
+  "Monitor": {
+    "screen_orientation": 0,
+    "follow_led_color": 0
+  },
+  "LED": {
+    "mode": 3,
+    "red_value": 0,
+    "green_value": 206,
+    "blue_value": 209,
+    "task_name": "task_led.py",
+    "is_run_on_startup": true
+  },
+  "Fan": {
+    "mode": 0,
+    "task_name": "task_fan.py",
+    "is_run_on_startup": true,
+    "mode1_fan_group1": 75,
+    "mode1_fan_group2": 75,
+    "mode2_low_temp_threshold": 30,
+    "mode2_high_temp_threshold": 50
+  },
+  "OLED": {
+    "task_name": "task_oled.py",
+    "is_run_on_startup": true,
+    "screen1": {
+      "data_format": 0,
+      "time_format": 0,
+      "display_time": 3.0,
+      "is_run_on_oled": true
+    },
+    "screen2": {
+      "interchange": 0,
+      "display_time": 3.0,
+      "is_run_on_oled": true
+    },
+    "screen3": {
+      "interchange": 0,
+      "display_time": 3.0,
+      "cpu_temp_celsius_or_fahrenheit": false,
+      "case_temp_celsius_or_fahrenheit": false,
+      "is_run_on_oled": true
+    },
+    "screen4": {
+      "interchange": 0,
+      "display_time": 3.0,
+      "is_run_on_oled": true
+    },
+    "screen5": {
+      "display_time": 3.0,
+      "is_run_on_oled": true
+    }
+  },
+  "Service": {
+    "is_exist_on_rpi": false,
+    "is_run_on_startup": false
+  }
+}

--- a/Code/app_ui.py
+++ b/Code/app_ui.py
@@ -624,12 +624,14 @@ class MainWindow(QMainWindow):
         """Send fan mode to expansion board"""
         if self.expansion.get_board_type() == "FNK0100":
             if mode == 0:
-                self.expansion.set_fan_mode(2)  
+                self.expansion.set_fan_frequency(50)
+                self.expansion.set_fan_mode(2)
                 self.expansion.set_fan_temp_mode_threshold(
                     self.fan_temp_mode_threshold[0],
                     self.fan_temp_mode_threshold[1]
                 )
             elif mode == 1:
+                self.expansion.set_fan_frequency(50)
                 self.expansion.set_fan_mode(1)
                 self.expansion.set_fan_duty(
                     self.fan_manual_mode_duty[0],
@@ -640,7 +642,9 @@ class MainWindow(QMainWindow):
                 self.expansion.set_fan_duty(0, 0)
         elif self.expansion.get_board_type() == "FNK0107":
             if mode == 0:
-                self.expansion.set_fan_mode(2)  
+                self.expansion.set_fan_frequency(50000)
+                self.expansion.set_fan_power_switch(1)
+                self.expansion.set_fan_mode(2)
                 self.expansion.set_fan_temp_mode_threshold(
                     self.fan_temp_mode_threshold[0],
                     self.fan_temp_mode_threshold[1],
@@ -652,12 +656,16 @@ class MainWindow(QMainWindow):
                     self.fan_temp_mode_duty[2]
                 )
             elif mode == 1:
+                self.expansion.set_fan_frequency(50000)
+                self.expansion.set_fan_power_switch(1)
                 self.expansion.set_fan_mode(3)
                 self.expansion.set_fan_pi_following(
                     self.fan_pi_follows_duty_map[0],
                     self.fan_pi_follows_duty_map[1]
                 )
             elif mode == 2:
+                self.expansion.set_fan_frequency(50000)
+                self.expansion.set_fan_power_switch(1)
                 self.expansion.set_fan_mode(1)
                 self.expansion.set_fan_duty(
                     self.fan_manual_mode_duty[0],
@@ -666,6 +674,7 @@ class MainWindow(QMainWindow):
                 )
             elif mode == 4:
                 self.expansion.set_fan_mode(0)
+                self.expansion.set_fan_power_switch(0)
                 self.expansion.set_fan_duty(0, 0, 0)
     def fan_radio_clicked_event(self):
         """Handle FAN mode switch event"""

--- a/Code/power_state.py
+++ b/Code/power_state.py
@@ -1,0 +1,66 @@
+import json
+import datetime
+
+try:
+    import redis as _redis_module
+    _REDIS_AVAILABLE = True
+except ImportError:
+    _REDIS_AVAILABLE = False
+
+_client = None
+_RATE_NIGHT = 22.98  # 平日23:00-6:00, 休日22:00-8:00
+_RATE_DAY   = 20.05  # 平日9:00-16:00, 休日8:00-22:00
+_RATE_LIFE  = 32.65  # 平日6:00-9:00 および 16:00-23:00（ライフタイム）
+_JST = datetime.timezone(datetime.timedelta(hours=9))
+
+
+def _get_client():
+    global _client
+    if _client is None and _REDIS_AVAILABLE:
+        try:
+            _client = _redis_module.Redis(host='localhost', port=6379, db=0, decode_responses=True)
+        except Exception:
+            pass
+    return _client
+
+
+def get_power_reading():
+    """Return current power consumption in watts from Redis, or None on failure."""
+    client = _get_client()
+    if client is None:
+        return None
+    try:
+        raw = client.get('my_key')
+        if raw is None:
+            return None
+        data = json.loads(raw)
+        return float(data['POWER']['value'])
+    except Exception:
+        return None
+
+
+def get_current_rate_yen_per_kwh():
+    """Return electricity rate (yen/kWh) based on current JST time and day type."""
+    now = datetime.datetime.now(tz=_JST)
+    hour = now.hour
+    is_weekend = now.weekday() >= 5  # 5=土, 6=日
+
+    if is_weekend:
+        if hour >= 22 or hour < 8:
+            return _RATE_NIGHT
+        else:
+            return _RATE_DAY
+    else:
+        if hour >= 23 or hour < 6:
+            return _RATE_NIGHT
+        elif 9 <= hour < 16:
+            return _RATE_DAY
+        else:
+            return _RATE_LIFE
+
+
+def get_hourly_cost_yen(watts):
+    """Return estimated cost in yen if watts were consumed for 1 hour, or None."""
+    if watts is None:
+        return None
+    return watts / 1000.0 * get_current_rate_yen_per_kwh()

--- a/Code/task_fan.py
+++ b/Code/task_fan.py
@@ -99,20 +99,29 @@ class FAN_TASK:
         middle_speed   = cfg['middle_speed']
         high_speed     = cfg['high_speed']
 
-        current_speed = low_speed
+        current_speed = 0  # Start in STOPPED state
         self._set_fan_duty(current_speed)
 
         try:
             while self.running:
                 temp = max(self._get_cpu_temp(), self._get_case_temp())
 
-                if temp >= high_threshold:
-                    current_speed = high_speed
-                elif temp >= low_threshold:
-                    current_speed = middle_speed
-                elif temp < low_threshold - schmitt:
-                    current_speed = low_speed
-                # else: stay in hysteresis band — keep current_speed unchanged
+                if current_speed == high_speed:
+                    if temp < high_threshold:
+                        current_speed = middle_speed
+                elif current_speed == middle_speed:
+                    if temp >= high_threshold:
+                        current_speed = high_speed
+                    elif temp < low_threshold:
+                        current_speed = low_speed
+                elif current_speed == low_speed:
+                    if temp >= low_threshold:
+                        current_speed = middle_speed
+                    elif temp < low_threshold - schmitt:
+                        current_speed = 0
+                else:  # STOPPED (0)
+                    if temp >= low_threshold:
+                        current_speed = middle_speed  # skip LOW on heating
 
                 self._set_fan_duty(current_speed)
                 time.sleep(5)

--- a/Code/task_fan.py
+++ b/Code/task_fan.py
@@ -86,7 +86,36 @@ class FAN_TASK:
 
     def run_fan_loop(self):
         """Follow Case: software Schmitt-trigger control using max(cpu_temp, case_temp)."""
-        self.expansion.set_fan_mode(1)   # Manual — duty set by this loop
+        # --- 起動後5分間: 旧test.pyの --fan テストと完全に同じロジック ---
+        # set_fan_mode(1), set_fan_frequency(50), duty 0→255→0スイープ (0.02秒/ステップ)
+        DEBUG_DURATION = 5 * 60
+        debug_start = time.time()
+
+        self.expansion.set_fan_mode(1)
+        self.expansion.set_fan_frequency(50)
+        if self.board_type == "FNK0107":
+            self.expansion.set_fan_power_switch(1)
+
+        try:
+            while self.running and (time.time() - debug_start) < DEBUG_DURATION:
+                for i in range(0, 256):
+                    if not self.running or (time.time() - debug_start) >= DEBUG_DURATION:
+                        break
+                    self._set_fan_duty(i)
+                    time.sleep(0.02)
+                for i in range(255, -1, -1):
+                    if not self.running or (time.time() - debug_start) >= DEBUG_DURATION:
+                        break
+                    self._set_fan_duty(i)
+                    time.sleep(0.02)
+        except KeyboardInterrupt:
+            return
+
+        if not self.running:
+            return
+
+        # --- 5分経過後: 通常のFollow Case制御に移行 ---
+        self.expansion.set_fan_mode(1)
         if self.board_type == "FNK0107":
             self.expansion.set_fan_frequency(50000)
             self.expansion.set_fan_power_switch(1)

--- a/Code/task_fan.py
+++ b/Code/task_fan.py
@@ -87,9 +87,11 @@ class FAN_TASK:
     def run_fan_loop(self):
         """Follow Case: software Schmitt-trigger control using max(cpu_temp, case_temp)."""
         self.expansion.set_fan_mode(1)   # Manual — duty set by this loop
-        self.expansion.set_fan_frequency(50)
         if self.board_type == "FNK0107":
+            self.expansion.set_fan_frequency(50000)
             self.expansion.set_fan_power_switch(1)
+        elif self.board_type == "FNK0100":
+            self.expansion.set_fan_frequency(50)
 
         cfg = self._load_fan_config()
         low_threshold  = cfg['low_threshold']

--- a/Code/task_fan.py
+++ b/Code/task_fan.py
@@ -87,7 +87,7 @@ class FAN_TASK:
     def run_fan_loop(self):
         """Follow Case: software Schmitt-trigger control using max(cpu_temp, case_temp)."""
         self.expansion.set_fan_mode(1)   # Manual — duty set by this loop
-        self.expansion.set_fan_frequency(50000)
+        self.expansion.set_fan_frequency(50)
         if self.board_type == "FNK0107":
             self.expansion.set_fan_power_switch(1)
 

--- a/Code/task_fan.py
+++ b/Code/task_fan.py
@@ -1,4 +1,6 @@
 from api_expansion import Expansion
+from api_systemInfo import SystemInformation
+from api_json import ConfigManager
 import atexit
 import signal
 import time
@@ -8,12 +10,18 @@ class FAN_TASK:
 
     def __init__(self):
         self.expansion = None
+        self.system_info = None
         self.board_type = None
-        self.running = True  # Add flag to control main loop
+        self.running = True
 
         try:
-            self.expansion = Expansion()                            # Initialize Expansion object
+            self.expansion = Expansion()
             self.board_type = self.expansion.get_board_type()
+        except Exception as e:
+            sys.exit(1)
+
+        try:
+            self.system_info = SystemInformation()
         except Exception as e:
             sys.exit(1)
 
@@ -40,52 +48,79 @@ class FAN_TASK:
                 self.expansion.end()
         except Exception as e:
             print(e)
-        
-        # Set running flag to False to exit main loop
+
         self.running = False
-        
-        # Only exit if called from signal handler (not from atexit)
+
         if signum is not None:
             pass
 
-    def run_fan_loop(self):
-        """Main monitoring loop - single-threaded infinite loop for both OLED display and fan control"""
-        self.expansion.set_fan_mode(1)
-        self.expansion.set_fan_frequency(50000) 
+    def _load_fan_config(self):
+        config = ConfigManager()
+        fan_cfg = config.get_section('Fan')
+        return {
+            'low_threshold':  fan_cfg.get('mode2_low_temp_threshold', 30),
+            'high_threshold': fan_cfg.get('mode2_high_temp_threshold', 50),
+            'schmitt':        fan_cfg.get('mode2_temp_schmitt', 3),
+            'low_speed':      fan_cfg.get('mode2_low_speed', 75),
+            'middle_speed':   fan_cfg.get('mode2_middle_speed', 125),
+            'high_speed':     fan_cfg.get('mode2_high_speed', 175),
+        }
+
+    def _get_cpu_temp(self):
+        try:
+            return self.system_info.get_raspberry_pi_cpu_temperature()
+        except Exception:
+            return 0.0
+
+    def _get_case_temp(self):
+        try:
+            return self.expansion.get_temp()
+        except Exception:
+            return 0.0
+
+    def _set_fan_duty(self, duty):
         if self.board_type == "FNK0100":
-            self.expansion.set_fan_temp_mode_threshold(50, 100)
+            self.expansion.set_fan_duty(duty, duty)
         elif self.board_type == "FNK0107":
-            self.expansion.set_fan_temp_mode_threshold(50, 100, 3)
-            self.expansion.set_fan_temp_mode_speed(75, 125, 175)
-            self.expansion.set_fan_pi_following(0, 100)
+            self.expansion.set_fan_duty(duty, duty, duty)
+
+    def run_fan_loop(self):
+        """Follow Case: software Schmitt-trigger control using max(cpu_temp, case_temp)."""
+        self.expansion.set_fan_mode(1)   # Manual — duty set by this loop
+        self.expansion.set_fan_frequency(50000)
+        if self.board_type == "FNK0107":
             self.expansion.set_fan_power_switch(1)
+
+        cfg = self._load_fan_config()
+        low_threshold  = cfg['low_threshold']
+        high_threshold = cfg['high_threshold']
+        schmitt        = cfg['schmitt']
+        low_speed      = cfg['low_speed']
+        middle_speed   = cfg['middle_speed']
+        high_speed     = cfg['high_speed']
+
+        current_speed = low_speed
+        self._set_fan_duty(current_speed)
 
         try:
             while self.running:
-                for i in range(0,255,1):
-                    if not self.running:
-                        break
-                    if self.board_type == "FNK0100":
-                        self.expansion.set_fan_duty(i, i)
-                    elif self.board_type == "FNK0107":
-                        self.expansion.set_fan_duty(i, i, i)
-                    time.sleep(0.01)
-                if not self.running:
-                    break
-                for i in range(255,0,-1):
-                    if not self.running:
-                        break
-                    if self.board_type == "FNK0100":
-                        self.expansion.set_fan_duty(i, i)
-                    elif self.board_type == "FNK0107":
-                        self.expansion.set_fan_duty(i, i, i)
-                    time.sleep(0.01)
+                temp = max(self._get_cpu_temp(), self._get_case_temp())
+
+                if temp >= high_threshold:
+                    current_speed = high_speed
+                elif temp >= low_threshold:
+                    current_speed = middle_speed
+                elif temp < low_threshold - schmitt:
+                    current_speed = low_speed
+                # else: stay in hysteresis band — keep current_speed unchanged
+
+                self._set_fan_duty(current_speed)
+                time.sleep(5)
         except KeyboardInterrupt:
-            # This will be caught by the signal handlers
             pass
 
 if __name__ == "__main__":
-    fan_task= None
+    fan_task = None
     try:
         fan_task = FAN_TASK()
         fan_task.run_fan_loop()

--- a/Code/task_led.py
+++ b/Code/task_led.py
@@ -1,18 +1,47 @@
 from api_expansion import Expansion
+from power_state import get_power_reading
 
 import atexit
 import signal
+import socket
 import time
 import sys
+
+_COLOR_LOW  = (0, 206, 209)   # water blue at low power
+_COLOR_HIGH = (255, 0, 0)     # red at high power
+_LOW_WATTS  = 2000
+_HIGH_WATTS = 4800
+
+
+def _is_network_connected():
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect(('10.255.255.255', 1))
+            return s.getsockname()[0] != '0.0.0.0'
+    except OSError:
+        return False
+
+
+def _power_to_color(watts):
+    if watts is None or watts <= _LOW_WATTS:
+        return _COLOR_LOW
+    if watts >= _HIGH_WATTS:
+        return _COLOR_HIGH
+    t = (watts - _LOW_WATTS) / (_HIGH_WATTS - _LOW_WATTS)
+    r = int(_COLOR_LOW[0] + t * (_COLOR_HIGH[0] - _COLOR_LOW[0]))
+    g = int(_COLOR_LOW[1] + t * (_COLOR_HIGH[1] - _COLOR_LOW[1]))
+    b = int(_COLOR_LOW[2] + t * (_COLOR_HIGH[2] - _COLOR_LOW[2]))
+    return (r, g, b)
+
 
 class LED_TASK:
 
     def __init__(self):
         self.expansion = None
-        self.running = True  # Add flag to control main loop
+        self.running = True
 
         try:
-            self.expansion = Expansion()                            # Initialize Expansion object
+            self.expansion = Expansion()
         except Exception as e:
             sys.exit(1)
 
@@ -36,90 +65,46 @@ class LED_TASK:
                 self.expansion.end()
         except Exception as e:
             print(e)
-        
-        # Set running flag to False to exit main loop
+
         self.running = False
 
-    def show_single_color(self):
-        """Main monitoring loop - single-threaded infinite loop for both OLED display and fan control"""
-        rainbow_colors = [
-            (255, 0, 0),    # 红色 (Red)
-            (0, 255, 0),    # 绿色 (Green)
-            (0, 0, 255),    # 蓝色 (Blue)
-            (255, 255, 0),  # 黄色 (Yellow)
-            (75, 0, 130),   # 靛蓝 (Indigo)
-            (0, 255, 255),  # 青色 (Cyan)
-            (255, 165, 0),  # 橙色 (Orange)
-            (128, 0, 128),  # 紫色 (Purple)
-            (255, 192, 203),# 粉色 (Pink)
-            (0, 128, 128),  # 青绿色 (Teal)
-            (64, 0, 128),   # 暗紫色 (Purple)
-            (255, 0, 255),  # 洋红 (Magenta)
-        ]
-        r,g,b = rainbow_colors[0]
-        self.expansion.set_led_mode(1)
-        self.expansion.set_all_led_color(r,g,b)
-        try:
-            while self.running:
-                for i in range(len(rainbow_colors)):
-                    if not self.running:
-                        break
-                    r,g,b = rainbow_colors[i]
-                    self.expansion.set_all_led_color(r,g,b)
-                    time.sleep(0.5)
-        except KeyboardInterrupt:
-            # This will be caught by the signal handlers
-            pass
-
-    def wheel(self, pos):
-        wheel_pos = pos % 255
-        if wheel_pos < 85:
-            r = 255 - wheel_pos * 3
-            g = wheel_pos * 3
-            b = 0
-            return (r, g, b)
-        if wheel_pos < 170:
-            wheel_pos -= 85
-            r = 0
-            g = 255 - wheel_pos * 3
-            b = wheel_pos * 3
-            return (r, g, b)
-        wheel_pos -= 170
-        r = wheel_pos * 3
-        g = 0
-        b = 255 - wheel_pos * 3
-        return (r, g, b)
-
-    def show_wheel_color(self):
-        '''显示彩虹色'''
-        self.expansion.set_led_mode(1)
-        try:
-            while self.running:
-                for i in range(255):
-                    if not self.running:
-                        break
-                    r,g,b = self.wheel(i)
-                    self.expansion.set_all_led_color(r,g,b)
-                    time.sleep(0.05)
-        except KeyboardInterrupt:
-            # This will be caught by the signal handlers
-            pass
-
-
     def run_led_loop(self):
-        """Main monitoring loop - single-threaded infinite loop for both OLED display and fan control"""
-        #self.show_single_color()
-        self.show_wheel_color()
+        """Power-based dynamic LED color: water-blue (low) to red (high), blinks red when offline."""
+        self.expansion.set_led_mode(1)  # Static RGB mode
+        r, g, b = _COLOR_LOW
+        self.expansion.set_all_led_color(r, g, b)
+
+        tick = 0
+        blink_on = False
+        online = True
+        try:
+            while self.running:
+                # Every 3 seconds (6 ticks × 0.5 s): refresh network status and power color
+                if tick % 6 == 0:
+                    online = _is_network_connected()
+                    if online:
+                        watts = get_power_reading()
+                        r, g, b = _power_to_color(watts)
+                        blink_on = False
+                        self.expansion.set_all_led_color(r, g, b)
+
+                # Every 0.5 s: toggle blink when offline
+                if not online:
+                    blink_on = not blink_on
+                    br, bg, bb = (255, 0, 0) if blink_on else (0, 0, 0)
+                    self.expansion.set_all_led_color(br, bg, bb)
+
+                tick += 1
+                time.sleep(0.5)
+        except KeyboardInterrupt:
+            pass
 
 
 if __name__ == "__main__":
-    led_task= None
+    led_task = None
     try:
         led_task = LED_TASK()
-
-        # Use simple infinite loop instead of threading
         led_task.run_led_loop()
-
     except KeyboardInterrupt:
         print("\nShutdown requested by user (Ctrl+C)")
     except Exception as e:

--- a/Code/task_led.py
+++ b/Code/task_led.py
@@ -3,6 +3,7 @@ from power_state import get_power_reading
 
 import atexit
 import json
+import math
 import os
 import signal
 import socket
@@ -11,8 +12,8 @@ import sys
 
 _COLOR_LOW  = (0, 206, 209)   # water blue at low power
 _COLOR_HIGH = (255, 0, 0)     # red at high power
-_LOW_WATTS  = 2000
-_HIGH_WATTS = 4800
+_LOW_WATTS  = 500
+_HIGH_WATTS = 5000
 
 # app_config.json LED.mode values (matches app_ui_led.py radio button order)
 _MODE_RAINBOW   = 0
@@ -55,7 +56,8 @@ def _power_to_color(watts):
         return _COLOR_LOW
     if watts >= _HIGH_WATTS:
         return _COLOR_HIGH
-    t = (watts - _LOW_WATTS) / (_HIGH_WATTS - _LOW_WATTS)
+    t = (math.log(watts) - math.log(_LOW_WATTS)) / (math.log(_HIGH_WATTS) - math.log(_LOW_WATTS))
+    t = max(0.0, min(1.0, t))
     r = int(_COLOR_LOW[0] + t * (_COLOR_HIGH[0] - _COLOR_LOW[0]))
     g = int(_COLOR_LOW[1] + t * (_COLOR_HIGH[1] - _COLOR_LOW[1]))
     b = int(_COLOR_LOW[2] + t * (_COLOR_HIGH[2] - _COLOR_LOW[2]))

--- a/Code/task_led.py
+++ b/Code/task_led.py
@@ -2,6 +2,8 @@ from api_expansion import Expansion
 from power_state import get_power_reading
 
 import atexit
+import json
+import os
 import signal
 import socket
 import time
@@ -12,6 +14,24 @@ _COLOR_HIGH = (255, 0, 0)     # red at high power
 _LOW_WATTS  = 2000
 _HIGH_WATTS = 4800
 
+# app_config.json LED.mode values (matches app_ui_led.py radio button order)
+_MODE_RAINBOW   = 0
+_MODE_BREATHING = 1
+_MODE_FOLLOW    = 2
+_MODE_MANUAL    = 3  # power-based color (replaces static single color)
+_MODE_CUSTOM    = 4  # same power-based logic (task_led.py custom mode)
+_MODE_CLOSE     = 5
+
+# Hardware set_led_mode() values from api_expansion comment:
+# 0: close, 1: RGB, 2: Following, 3: Breathing, 4: Rainbow
+_HW_CLOSE     = 0
+_HW_RGB       = 1
+_HW_FOLLOWING = 2
+_HW_BREATHING = 3
+_HW_RAINBOW   = 4
+
+_CONFIG_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'app_config.json')
+
 
 def _is_network_connected():
     try:
@@ -20,6 +40,14 @@ def _is_network_connected():
             return s.getsockname()[0] != '0.0.0.0'
     except OSError:
         return False
+
+
+def _read_config():
+    try:
+        with open(_CONFIG_PATH, 'r') as f:
+            return json.load(f)
+    except Exception:
+        return {}
 
 
 def _power_to_color(watts):
@@ -32,6 +60,17 @@ def _power_to_color(watts):
     g = int(_COLOR_LOW[1] + t * (_COLOR_HIGH[1] - _COLOR_LOW[1]))
     b = int(_COLOR_LOW[2] + t * (_COLOR_HIGH[2] - _COLOR_LOW[2]))
     return (r, g, b)
+
+
+def _rainbow_step(pos):
+    pos = pos % 255
+    if pos < 85:
+        return (255 - pos * 3, pos * 3, 0)
+    if pos < 170:
+        pos -= 85
+        return (0, 255 - pos * 3, pos * 3)
+    pos -= 170
+    return (pos * 3, 0, 255 - pos * 3)
 
 
 class LED_TASK:
@@ -52,7 +91,7 @@ class LED_TASK:
     def handle_signal(self, signum=None, frame=None):
         try:
             if self.expansion:
-                self.expansion.set_led_mode(0)
+                self.expansion.set_led_mode(_HW_CLOSE)
         except Exception as e:
             print(e)
         try:
@@ -65,37 +104,103 @@ class LED_TASK:
                 self.expansion.end()
         except Exception as e:
             print(e)
-
         self.running = False
 
     def run_led_loop(self):
-        """Power-based dynamic LED color: water-blue (low) to red (high), blinks red when offline."""
-        self.expansion.set_led_mode(1)  # Static RGB mode
-        r, g, b = _COLOR_LOW
-        self.expansion.set_all_led_color(r, g, b)
+        """Main loop: reads LED.mode from app_config.json every 3 s and dispatches accordingly.
 
-        tick = 0
+        mode 0 (Rainbow)  → software rainbow wheel (original show_wheel_color behavior)
+        mode 1 (Breathing)→ hardware breathing with configured color
+        mode 2 (Follow)   → hardware following with configured color
+        mode 3 (Manual)   → power-based dynamic color (custom: water-blue→red by wattage)
+        mode 4 (Custom)   → same power-based logic as mode 3
+        mode 5 (Close)    → LEDs off
+        """
+        config = _read_config()
+        last_config_read = time.monotonic()
+
+        # power-mode state
         blink_on = False
         online = True
+        power_r, power_g, power_b = _COLOR_LOW
+        last_power_check = 0.0
+
+        # rainbow state
+        rainbow_pos = 0
+
+        # track hardware mode to avoid redundant set_led_mode calls
+        hw_mode = None
+
         try:
             while self.running:
-                # Every 3 seconds (6 ticks × 0.5 s): refresh network status and power color
-                if tick % 6 == 0:
-                    online = _is_network_connected()
-                    if online:
-                        watts = get_power_reading()
-                        r, g, b = _power_to_color(watts)
-                        blink_on = False
+                now = time.monotonic()
+
+                if now - last_config_read >= 3.0:
+                    config = _read_config()
+                    last_config_read = now
+
+                led_cfg = config.get('LED', {})
+                mode = led_cfg.get('mode', _MODE_MANUAL)
+
+                if mode == _MODE_RAINBOW:
+                    r, g, b = _rainbow_step(rainbow_pos)
+                    if hw_mode != _HW_RGB:
+                        self.expansion.set_led_mode(_HW_RGB)
+                        hw_mode = _HW_RGB
+                    self.expansion.set_all_led_color(r, g, b)
+                    rainbow_pos = (rainbow_pos + 1) % 255
+                    time.sleep(0.05)
+
+                elif mode == _MODE_BREATHING:
+                    r = led_cfg.get('red_value', 0)
+                    g = led_cfg.get('green_value', 0)
+                    b = led_cfg.get('blue_value', 255)
+                    if hw_mode != _HW_BREATHING:
+                        self.expansion.set_led_mode(_HW_BREATHING)
                         self.expansion.set_all_led_color(r, g, b)
+                        hw_mode = _HW_BREATHING
+                    time.sleep(0.5)
 
-                # Every 0.5 s: toggle blink when offline
-                if not online:
-                    blink_on = not blink_on
-                    br, bg, bb = (255, 0, 0) if blink_on else (0, 0, 0)
-                    self.expansion.set_all_led_color(br, bg, bb)
+                elif mode == _MODE_FOLLOW:
+                    r = led_cfg.get('red_value', 0)
+                    g = led_cfg.get('green_value', 0)
+                    b = led_cfg.get('blue_value', 255)
+                    if hw_mode != _HW_FOLLOWING:
+                        self.expansion.set_led_mode(_HW_FOLLOWING)
+                        self.expansion.set_all_led_color(r, g, b)
+                        hw_mode = _HW_FOLLOWING
+                    time.sleep(0.5)
 
-                tick += 1
-                time.sleep(0.5)
+                elif mode in (_MODE_MANUAL, _MODE_CUSTOM):
+                    if hw_mode != _HW_RGB:
+                        self.expansion.set_led_mode(_HW_RGB)
+                        hw_mode = _HW_RGB
+
+                    if now - last_power_check >= 3.0:
+                        last_power_check = now
+                        online = _is_network_connected()
+                        if online:
+                            watts = get_power_reading()
+                            power_r, power_g, power_b = _power_to_color(watts)
+                            blink_on = False
+                            self.expansion.set_all_led_color(power_r, power_g, power_b)
+
+                    if not online:
+                        blink_on = not blink_on
+                        br, bg, bb = (255, 0, 0) if blink_on else (0, 0, 0)
+                        self.expansion.set_all_led_color(br, bg, bb)
+
+                    time.sleep(0.5)
+
+                elif mode == _MODE_CLOSE:
+                    if hw_mode != _HW_CLOSE:
+                        self.expansion.set_led_mode(_HW_CLOSE)
+                        hw_mode = _HW_CLOSE
+                    time.sleep(0.5)
+
+                else:
+                    time.sleep(0.5)
+
         except KeyboardInterrupt:
             pass
 

--- a/Code/task_manager.py
+++ b/Code/task_manager.py
@@ -53,16 +53,32 @@ class TaskManager:
     
     def send_fan_mode_to_expansion(self, mode):
         """Send fan mode to expansion board"""
-        if self.expansion.get_board_type() == "FNK0100":
+        fan_config = self.config_manager.get_section('Fan')
+        board = self.expansion.get_board_type()
+        if board == "FNK0100":
             if mode == 0:
-                self.expansion.set_fan_mode(2)  
+                low  = fan_config.get('mode2_low_temp_threshold', 30)
+                high = fan_config.get('mode2_high_temp_threshold', 50)
+                self.expansion.set_fan_frequency(50000)
+                self.expansion.set_fan_temp_mode_threshold(low, high)
+                self.expansion.set_fan_mode(2)
             elif mode == 1:
                 self.expansion.set_fan_mode(1)
             elif mode == 3:
                 self.expansion.set_fan_mode(0)
-        elif self.expansion.get_board_type() == "FNK0107":
+        elif board == "FNK0107":
             if mode == 0:
-                self.expansion.set_fan_mode(2)  
+                low    = fan_config.get('mode2_low_temp_threshold', 30)
+                high   = fan_config.get('mode2_high_temp_threshold', 50)
+                schmitt = fan_config.get('mode2_temp_schmitt', 3)
+                low_spd = fan_config.get('mode2_low_speed', 75)
+                mid_spd = fan_config.get('mode2_middle_speed', 125)
+                hi_spd  = fan_config.get('mode2_high_speed', 175)
+                self.expansion.set_fan_frequency(50000)
+                self.expansion.set_fan_temp_mode_threshold(low, high, schmitt)
+                self.expansion.set_fan_temp_mode_speed(low_spd, mid_spd, hi_spd)
+                self.expansion.set_fan_power_switch(1)
+                self.expansion.set_fan_mode(2)
             elif mode == 1:
                 self.expansion.set_fan_mode(3)
             elif mode == 2:

--- a/Code/task_oled.py
+++ b/Code/task_oled.py
@@ -2,6 +2,7 @@ from api_oled import OLED
 from api_expansion import Expansion
 from api_systemInfo import SystemInformation
 from api_json import ConfigManager
+from power_state import get_power_reading, get_hourly_cost_yen
 import atexit
 import signal
 import time
@@ -20,7 +21,7 @@ class OLED_TASK:
         self.is_convert_case_temp_to_fahrenheit = False
         self.font_size = 12
         self.running = True  # Add flag to control main loop
-        
+
         # Initialize config manager
         self.config_manager = ConfigManager()
         self.screen1_data_format = self.config_manager.get_value('OLED', 'screen1').get('data_format', 0)
@@ -58,7 +59,7 @@ class OLED_TASK:
     def celsius_to_fahrenheit(self, celsius):
         """Convert Celsius to Fahrenheit"""
         return (celsius * 9/5) + 32
-    
+
     def get_computer_temperature(self):
         # Get the computer temperature using Expansion object
         try:
@@ -93,7 +94,7 @@ class OLED_TASK:
                 self.oled.close()
         except Exception as e:
             print(e)
-        
+
         # Set running flag to False to exit main loop
         self.running = False
 
@@ -135,7 +136,7 @@ class OLED_TASK:
         self.oled.draw_rectangle((0, 0, self.oled.width-1, self.oled.height-1), outline="white")
         self.oled.draw_line(((0, 16), (self.oled.width-1, 16)), fill="white")
         self.oled.draw_line(((0, 48), (self.oled.width-1, 48)), fill="white")
-        
+
         # Update configuration
         self.screen1_data_format = self.config_manager.get_value('OLED', 'screen1').get('data_format', 0)
         self.screen1_time_format = self.config_manager.get_value('OLED', 'screen1').get('time_format', 0)
@@ -217,18 +218,18 @@ class OLED_TASK:
             cpu_circle_pos = (21,46)
             mem_circle_pos = (64,46)
             disk_circle_pos = (107,46)
-        
+
         # Draw text labels in specified positions
         self.oled.draw_text("CPU",  position=cpu_pos, directory="center", offset=(0, 0), font_size=self.font_size)
         self.oled.draw_text("MEM",  position=mem_pos, directory="center", offset=(0, 0), font_size=self.font_size)
         self.oled.draw_text("DISK", position=disk_pos, directory="center", offset=(0, 0), font_size=self.font_size)
-        
+
         # Draw percentage circles in corresponding positions
         self.oled.draw_circle_with_percentage(cpu_circle_pos, 16, cpu_usage, outline="white", fill="white")
         self.oled.draw_circle_with_percentage(mem_circle_pos, 16, memory_usage, outline="white", fill="white")
         self.oled.draw_circle_with_percentage(disk_circle_pos, 16, disk_usage, outline="white", fill="white")
         self.oled.show()
-    
+
     def oled_ui_3_show(self, pi_temperature, cpu_temperature):
         self.oled.clear()
 
@@ -285,10 +286,10 @@ class OLED_TASK:
         self.oled.draw_rectangle((0, 0, self.oled.width-1, self.oled.height-1), outline="white")
         self.oled.draw_line(((43, 0), (43, self.oled.height-1)), fill="white")
         self.oled.draw_line(((86, 0), (86, self.oled.height-1)), fill="white")
-        
+
         # Get screen4 interchange setting
         self.screen4_interchange = self.config_manager.get_value('OLED', 'screen4').get('interchange', 0)
-        
+
         # Define positions based on interchange setting
         if self.screen4_interchange == 1:
             # Order: Pi, C2, C1
@@ -356,23 +357,32 @@ class OLED_TASK:
             pi_percent_pos = ((0,48),(42,64))
             c1_percent_pos = ((43,48),(85,64))
             c2_percent_pos = ((86,48),(128,64))
-        
+
         # Write titles in first row
         self.oled.draw_text("Pi",  position=pi_pos, directory="center", offset=(0, 0), font_size=self.font_size)
         self.oled.draw_text("C1",  position=c1_pos, directory="center", offset=(0, 0), font_size=self.font_size)
         self.oled.draw_text("C2",  position=c2_pos, directory="center", offset=(0, 0), font_size=self.font_size)
-        
+
         # Draw dials in second row
         percentage_value = [round(duty[i]/255*100) for i in range(3)]
         self.oled.draw_dial(center_xy=pi_dial_pos, radius=16, angle=(225, 315), directory="CW", tick_count=10, percentage=percentage_value[0], start_value=0, end_value=100)
         self.oled.draw_dial(center_xy=c1_dial_pos, radius=16, angle=(225, 315), directory="CW", tick_count=10, percentage=percentage_value[1], start_value=0, end_value=100)
         self.oled.draw_dial(center_xy=c2_dial_pos, radius=16, angle=(225, 315), directory="CW", tick_count=10, percentage=percentage_value[2], start_value=0, end_value=100)
-        
+
         # Print duty cycle percentage values in third row
         self.oled.draw_text("{}%".format(percentage_value[0]), position=pi_percent_pos, directory="center", offset=(0, 0), font_size=self.font_size)
         self.oled.draw_text("{}%".format(percentage_value[1]), position=c1_percent_pos, directory="center", offset=(0, 0), font_size=self.font_size)
         self.oled.draw_text("{}%".format(percentage_value[2]), position=c2_percent_pos, directory="center", offset=(0, 0), font_size=self.font_size)
-        
+
+        self.oled.show()
+
+    def oled_ui_5_show(self, power_watts, hourly_cost_yen):
+        """Screen 5: current power draw and estimated hourly cost."""
+        self.oled.clear()
+        power_text = f"{power_watts:.0f}W" if power_watts is not None else "---W"
+        cost_text  = f"\xa5{hourly_cost_yen:.0f}/h" if hourly_cost_yen is not None else "\xa5---/h"
+        self.oled.draw_text(power_text, position=((0, 0), (128, 32)), directory="center", offset=(0, 4), font_size=24)
+        self.oled.draw_text(cost_text,  position=((0, 32), (128, 64)), directory="center", offset=(0, 4), font_size=24)
         self.oled.show()
 
     def run_oled_loop(self):
@@ -380,7 +390,7 @@ class OLED_TASK:
         oled_counter = 0  # Counter to control OLED update frequency
         screen_start_time = time.time()  # Record the start time of current screen
         current_screen = 0  # Current screen index
-        
+
         while self.running:
             # Update data every 0.3 seconds
             current_date = self.system_information.get_raspberry_pi_date()
@@ -397,59 +407,69 @@ class OLED_TASK:
 
             current_pi_duty = self.system_information.get_raspberry_pi_fan_duty()
             computer_fan_duty = self.get_computer_fan_duty()
-            
+
+            power_watts = get_power_reading()
+            hourly_cost_yen = get_hourly_cost_yen(power_watts)
+
             # Get display time configuration for each screen
             screen1_duration = self.config_manager.get_value('OLED', 'screen1').get('display_time', 3.0)
             screen2_duration = self.config_manager.get_value('OLED', 'screen2').get('display_time', 3.0)
             screen3_duration = self.config_manager.get_value('OLED', 'screen3').get('display_time', 3.0)
             screen4_duration = self.config_manager.get_value('OLED', 'screen4').get('display_time', 3.0)
+            screen5_duration = (self.config_manager.get_value('OLED', 'screen5') or {}).get('display_time', 3.0)
 
             screen1_is_run_on_oled = self.config_manager.get_value('OLED', 'screen1').get('is_run_on_oled', True)
             screen2_is_run_on_oled = self.config_manager.get_value('OLED', 'screen2').get('is_run_on_oled', True)
             screen3_is_run_on_oled = self.config_manager.get_value('OLED', 'screen3').get('is_run_on_oled', True)
             screen4_is_run_on_oled = self.config_manager.get_value('OLED', 'screen4').get('is_run_on_oled', True)
+            screen5_is_run_on_oled = (self.config_manager.get_value('OLED', 'screen5') or {}).get('is_run_on_oled', True)
 
             # Determine which screens need to be displayed according to configuration
             active_screens = []
             screen_durations = []
             screen_functions = []
-            
+
             if screen1_is_run_on_oled:
                 active_screens.append(0)
                 screen_durations.append(screen1_duration)
                 screen_functions.append(lambda: self.oled_ui_1_show(current_date, current_weekday, current_time))
-            
+
             if screen2_is_run_on_oled:
                 active_screens.append(1)
                 screen_durations.append(screen2_duration)
                 screen_functions.append(lambda: self.oled_ui_2_show(ip_address, cpu_usage, memory_usage[0], disk_usage[0]))
-            
+
             if screen3_is_run_on_oled:
                 active_screens.append(2)
                 screen_durations.append(screen3_duration)
                 screen_functions.append(lambda: self.oled_ui_3_show(cpu_temperature, computer_temperature))
-            
+
             if screen4_is_run_on_oled:
                 active_screens.append(3)
                 screen_durations.append(screen4_duration)
                 screen_functions.append(lambda: self.oled_ui_4_show([current_pi_duty, computer_fan_duty[0], computer_fan_duty[1]]))
-            
+
+            if screen5_is_run_on_oled:
+                active_screens.append(4)
+                screen_durations.append(screen5_duration)
+                screen_functions.append(lambda: self.oled_ui_5_show(power_watts, hourly_cost_yen))
+
             # Skip if no active screens
             if not active_screens:
                 time.sleep(0.3)
                 continue
-            
+
             # Get the current active screen index
             current_active_index = current_screen % len(active_screens)
             current_screen_index = active_screens[current_active_index]
-            
+
             # Check if screen needs to be switched (based on time instead of counter)
             elapsed_time = time.time() - screen_start_time
             if elapsed_time >= screen_durations[current_active_index]:
                 current_screen = (current_screen + 1) % len(active_screens)
                 current_active_index = current_screen % len(active_screens)
                 screen_start_time = time.time()
-            
+
             # Update OLED every 0.3 seconds
             try:
                 # Use the function of current active screen


### PR DESCRIPTION
## 目的

fanが動かない問題の切り分けのため、`task_fan.py` の起動後5分間だけ、旧 `test.py --fan` と完全に同じシーケンスで動作させる。

## 旧test.pyのfanテスト実装（再現元）

```python
expansion_board.set_fan_mode(1)
expansion_board.set_fan_frequency(50)
while True:
    for i in range(0, 256):
        expansion_board.set_fan_duty(i, i)
        time.sleep(0.02)
    for i in range(255, -1, -1):
        expansion_board.set_fan_duty(i, i)
        time.sleep(0.02)
```

## 変更内容

`run_fan_loop()` 先頭に5分間のデバッグフェーズを追加：
- `set_fan_mode(1)` → Manual mode
- `set_fan_frequency(50)` → 旧テストと同じ50Hz（ボード型問わず）
- FNK0107のみ: `set_fan_power_switch(1)` → ファンハードウェア有効化（これなしでは動かない）
- duty 0→255→0 を0.02秒/ステップでスイープ（旧テストと完全に同一）
- 5分経過後: 通常のFollow Case制御に自動移行

## テスト方法

```bash
python3 task_fan.py
# 起動直後からファンがゆっくり→速く→ゆっくりと回れば成功
# 5分後に自動的に温度ベース制御に切り替わる
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)